### PR TITLE
Prevent whitespace and newline from being displayed in Code Node

### DIFF
--- a/src/runtime/components/blocks/CodeNode.vue
+++ b/src/runtime/components/blocks/CodeNode.vue
@@ -1,5 +1,3 @@
 <template>
-    <pre>
-        <slot />
-    </pre>
+    <pre><slot /></pre>
 </template>


### PR DESCRIPTION
This PR should address an issue with the white space and new line that appears in the `<pre>` code blocks. Picture below displays the current issue.

<img width="809" alt="image" src="https://github.com/user-attachments/assets/68b761c5-81fc-4c60-bbce-2c03780320c6">


I first attempted a fix by changing the whitespace class in CSS. While it fixes the new line issue, the whitespace for the tabbing is not preserved.

<img width="404" alt="image" src="https://github.com/user-attachments/assets/c2736797-d31a-4ea4-879b-3160e6f0c5b7">
