### PR TITLE
Improve README: Add Note on ~/components to Prevent Resolution Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,16 @@ export default defineNuxtConfig({
                 pathPrefix: false,
                 global: true,
             },
+            // also include ~/components to ensure other local components are resolved properly
+            '~/components'
         ],
     },
 })
 ```
+
+> [!IMPORTANT]  
+> It's important to include `~/components` in the dirs array.
+> Omitting it may cause locally scoped components (outside of `~/components/blocks`) not to resolve correctly. 
 
 #### Customizing the Paragraph Tag
 


### PR DESCRIPTION
Updated README.md to help users avoid the issue described in #44 by clarifying the need to include '~/components' in the Nuxt components.dirs array.